### PR TITLE
CI: Set content permission to 'write'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@
 # This file is modified by Mrmayman, ApicalShark on 2024
 
 name: Release
+
+permissions:
+  contents: write
+
 on:
   workflow_dispatch: # allows manual triggering
 


### PR DESCRIPTION
Override the default permissions for the GitHub Action.