### PR TITLE
Fix build-rpm.yml: ensure dnf5 builddep runs on Fedora 40 and address semicolon issues

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -16,20 +16,29 @@ jobs:
     name: Fedora
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.docker }}
+      image: ${{ matrix.altarch }}/${{ matrix.os }}:${{ matrix.version }}
     strategy:
       fail-fast: false
       matrix:
-        docker: [amd64/fedora:latest, amd64/fedora:40]
+        docker: [fedora-latest, fedora-40]
         include:
-        - docker: amd64/fedora:latest
-          os: fedora-latest
+        - docker: fedora-latest
+          version: latest
+          os: fedora
           arch: x86_64
+          altarch: amd64
+        - docker: fedora-40
+          version: 40
+          os: fedora
+          arch: x86_64
+          altarch: amd64
+          
     
     steps:
       - name: Install Build Dependencies
         run: |
-          sudo dnf install rpmdevtools rpmlint @development-tools rpkg git --refresh -y
+          sudo dnf install rpmdevtools rpmlint @development-tools rpkg git dnf5 dnf5-plugins --refresh -y
+          sudo dnf install dnf5-command\(builddep\) -y
       
       - name: Clone Repo
         run: |
@@ -38,7 +47,7 @@ jobs:
       - name: Build release package
         run: |
           cd quantum-launcher
-          sudo dnf builddep -y quantum_launcher.spec
+          sudo dnf5 builddep -y quantum_launcher.spec
           mkdir ~/rpmlocal && rpkg local --outdir ~/rpmlocal
           rm -f ~/rpmlocal/${{ matrix.arch }}/*debug*
 
@@ -50,5 +59,5 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: quantum-launcher-${{ matrix.os}}-${{ matrix.arch }}
+          name: quantum-launcher-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
           path: dist


### PR DESCRIPTION
- Ensure dnf5 build dependencies run on the Fedora 40 Docker image.
- Address issues caused by semicolons that break the runner.