### PR TITLE
Add community fix for missing xrandr causing Minecraft launch failure on Wayland/minimal X11 configurations

### DIFF
--- a/docs/community-fixes.md
+++ b/docs/community-fixes.md
@@ -116,6 +116,16 @@ If the xrandr command is not installed or missing from $PATH, Minecraft may fail
 This can happen both on X11 and on Wayland (when running through XWayland).
 
 
+```log
+
+java.lang.ExceptionInInitializerError ...
+Caused by: java.lang.ArrayIndexOutOfBoundsException: 0
+        at org.lwjgl.opengl.LinuxDisplay.getAvailableDisplayModes(LinuxDisplay.java:951)
+        at org.lwjgl.opengl.LinuxDisplay.init(LinuxDisplay.java:738)
+        at org.lwjgl.opengl.Display.<clinit>(Display.java:138)
+
+```
+
 **Fix**
 
 Install `xrandr` using your package manager.


### PR DESCRIPTION
Older Minecraft versions have a hardcoded dependency on the xrandr command for display handling.
On Wayland or minimal X11 setups where xrandr isn’t installed, the game fails to start.