### PR TITLE
Added support for installing data-packs

### DIFF
--- a/crates/ql_mod_manager/src/store/curseforge/download.rs
+++ b/crates/ql_mod_manager/src/store/curseforge/download.rs
@@ -121,6 +121,7 @@ impl<'a> ModDownloader<'a> {
         };
 
         let dir = match query_type {
+            QueryType::DataPacks => &self.dirs.data_packs,
             QueryType::Mods => &self.dirs.mods,
             QueryType::ResourcePacks => &self.dirs.resource_packs,
             QueryType::Shaders => &self.dirs.shaders,

--- a/crates/ql_mod_manager/src/store/curseforge/mod.rs
+++ b/crates/ql_mod_manager/src/store/curseforge/mod.rs
@@ -222,7 +222,13 @@ impl Backend for CurseforgeBackend {
 
         let categories = get_categories().await?;
         let query_type_str = query_type.to_curseforge_str();
-        if let Some(category) = categories.data.iter().find(|n| n.slug == query_type_str) {
+        if query_type == QueryType::DataPacks {
+            // curseforge returns categories that have the same slug but have different ids
+            // for example this 2 have the same slug: "data-packs"
+            // - path: /data-packs                  id: 6945 (the right one)
+            // - path: /texture-packs/data-packs    id: 5139 (actually texture packs)
+            params.insert("classId", 6945.to_string());
+        } else if let Some(category) = categories.data.iter().find(|n| n.slug == query_type_str) {
             params.insert("classId", category.id.to_string());
         }
 

--- a/crates/ql_mod_manager/src/store/mod.rs
+++ b/crates/ql_mod_manager/src/store/mod.rs
@@ -156,8 +156,8 @@ pub enum QueryType {
     ResourcePacks,
     Shaders,
     ModPacks,
+    DataPacks,
     // TODO:
-    // DataPacks,
     // Plugins,
 }
 
@@ -171,17 +171,30 @@ impl Display for QueryType {
                 QueryType::ResourcePacks => "Resource Packs",
                 QueryType::Shaders => "Shaders",
                 QueryType::ModPacks => "Modpacks",
+                QueryType::DataPacks => "Data Packs",
             }
         )
     }
 }
 
 impl QueryType {
-    pub const ALL: &'static [Self] = &[
+    // use this for the store since datapacks cant be installed globally,
+    // only pre worlds, since you need to copy the datapack file into each world
+    // once the launcher have support for installing datapacks properly delete this
+    // and use ALL in the store too.
+    pub const STORE_QUERIES: &'static [Self] = &[
         Self::Mods,
         Self::ResourcePacks,
         Self::Shaders,
         Self::ModPacks,
+    ];
+
+    pub const ALL: &'static [Self] = &[
+        Self::DataPacks,
+        Self::ResourcePacks,
+        Self::ModPacks,
+        Self::Mods,
+        Self::Shaders,
     ];
 
     #[must_use]
@@ -191,6 +204,7 @@ impl QueryType {
             QueryType::ResourcePacks => "resourcepack",
             QueryType::Shaders => "shader",
             QueryType::ModPacks => "modpack",
+            QueryType::DataPacks => "datapack",
         }
     }
 
@@ -201,6 +215,7 @@ impl QueryType {
             "resourcepack" => Some(QueryType::ResourcePacks),
             "shader" => Some(QueryType::Shaders),
             "modpack" => Some(QueryType::ModPacks),
+            "datapack" => Some(QueryType::DataPacks),
             _ => None,
         }
     }
@@ -212,6 +227,7 @@ impl QueryType {
             QueryType::ResourcePacks => "texture-packs",
             QueryType::Shaders => "shaders",
             QueryType::ModPacks => "modpacks",
+            QueryType::DataPacks => "data-packs",
         }
     }
 
@@ -222,6 +238,7 @@ impl QueryType {
             "texture-packs" => Some(QueryType::ResourcePacks),
             "shaders" => Some(QueryType::Shaders),
             "modpacks" => Some(QueryType::ModPacks),
+            "data-packs" => Some(QueryType::DataPacks),
             _ => None,
         }
     }
@@ -265,6 +282,7 @@ struct DirStructure {
     mods: PathBuf,
     resource_packs: PathBuf,
     shaders: PathBuf,
+    data_packs: PathBuf,
 }
 
 impl DirStructure {
@@ -277,6 +295,14 @@ impl DirStructure {
         const V1_6_1: &str = "2013-06-08T00:32:01+00:00";
 
         let dot_minecraft_dir = instance_name.get_dot_minecraft_path();
+
+        // this doesn't get loaded by default but there are datapack loader mods
+        // that are used my modpacks that want to include datapacks.
+        // for example https://modrinth.com/mod/dataloader
+        let data_packs = dot_minecraft_dir.join("datapacks");
+        tokio::fs::create_dir_all(&data_packs)
+            .await
+            .path(&data_packs)?;
 
         let resource_packs = if version_json.is_before_or_eq(V1_6_1) {
             "texturepacks"
@@ -292,17 +318,22 @@ impl DirStructure {
         let shaders = dot_minecraft_dir.join("shaderpacks");
         tokio::fs::create_dir_all(&shaders).await.path(&shaders)?;
 
+        let mods = dot_minecraft_dir.join("mods");
+        tokio::fs::create_dir_all(&mods).await.path(&mods)?;
+
         Ok(Self {
-            mods: dot_minecraft_dir.join("mods"),
+            mods,
             resource_packs,
             shaders,
+            data_packs,
         })
     }
 
     pub fn get(&self, query_type: QueryType) -> Result<PathBuf, PackError> {
         Ok(match query_type {
-            QueryType::Mods => self.mods.clone(),
+            QueryType::DataPacks => self.data_packs.clone(),
             QueryType::ResourcePacks => self.resource_packs.clone(),
+            QueryType::Mods => self.mods.clone(),
             QueryType::Shaders => self.shaders.clone(),
             QueryType::ModPacks => return Err(PackError::ModpackInModpack),
         })

--- a/quantum_launcher/src/menu_renderer/mods/mods_store.rs
+++ b/quantum_launcher/src/menu_renderer/mods/mods_store.rs
@@ -111,7 +111,7 @@ impl MenuModsDownload {
             .size(14),
             widget::Space::with_height(5),
             widget::text("Select Type:").size(18),
-            widget::column(QueryType::ALL.iter().map(|n| {
+            widget::column(QueryType::STORE_QUERIES.iter().map(|n| {
                 widget::radio(n.to_string(), *n, Some(self.query_type), |v| {
                     Message::InstallMods(InstallModsMessage::ChangeQueryType(v))
                 })


### PR DESCRIPTION
This fixes installation failure of mod-packs that include data-packs, but searching is intentionally skipped since installing data-packs globally isn't possible without a mod.

same as #93
needs testing