### PR TITLE
RFC: Add rust-toolchain.toml to pin compiler to v1.82.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6996,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "5.1.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+checksum = "c7bd5b91aa407cb977468d108ca3fede2c992ea44bb1d989e21756749d7dccff"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/quantum_launcher/src/stylesheet/styles.rs
+++ b/quantum_launcher/src/stylesheet/styles.rs
@@ -759,10 +759,10 @@ fn radius(t: bool) -> f32 {
 
 fn blend_colors(color1: iced::Color, color2: iced::Color) -> iced::Color {
     // Calculate the average of each RGBA component
-    let r = color1.r.midpoint(color2.r);
-    let g = color1.g.midpoint(color2.g);
-    let b = color1.b.midpoint(color2.b);
-    let a = color1.a.midpoint(color2.a);
+    let r = (color1.r + color2.r) / 2.0;
+    let g = (color1.g + color2.g) / 2.0;
+    let b = (color1.b + color2.b) / 2.0;
+    let a = (color1.a + color2.a) / 2.0;
 
     // Return a new Color with the blended RGBA values
     iced::Color::from_rgba(r, g, b, a)

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,10 @@
+# Minimum Supported Rust Version (MSRV) for QuantumLauncher
+# See the top level README.md for more information
+#
+# This file pins the Rust version to ensure consistent builds
+# and prevents accidentally using newer language features.
+
+[toolchain]
+channel = "1.82.0"
+
+components = ["rustfmt", "clippy", "rust-src","rust-analyzer"]


### PR DESCRIPTION
# tl;dr
This PR pins the Rust compiler version to `1.82.0` to enforce the project's documented MSRV (Minimum Supported Rust Version) as stated in the top level README.

# changes

- Added rust-toolchain.toml: Pins the compiler to `1.82.0` with clippy, rustfmt, and rust-src.
- Fixed styles.rs: Replaced f32::midpoint() (stabilized in `1.85.0`) with (a + b) / 2.0 to restore compatibility with the 1.82.0 toolchain.

# Why?

**Enforcement**: Currently, the top level README claims `1.82.0` support, but the code actually requires `1.85.1`. A rust-toolchain.toml makes our MSRV a hard rule rather than a "suggestion." 

**Dependency Constraints**: Modern versions of core dependencies (like zip v5.1+) already require `1.83.0+`. Pinning to `1.82.0` prevents us from accidentally bumping into incompatible dependency versions.
