### PR TITLE
CI: Correct `MACOSX_DEPLOYMENT_TARGET` depending on the Mac

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,18 +15,22 @@ jobs:
   dist:
     name: Dist
     runs-on: ${{ matrix.os }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.dep_target }}
     strategy:
       fail-fast: false
       matrix:
         build: [x86_64-macos, aarch64-macos]
         include:
           - build: x86_64-macos
+            dep_target: 10.15 # all pre-M1 devices
             os: macos-latest
             rust: stable
             target: x86_64-apple-darwin
             cross: false
             final_name: macos_x86_64
           - build: aarch64-macos
+            dep_target: 11 # M1 & post-M1
             os: macos-latest
             rust: stable
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name (e.g. v1.0.0)'
+        description: "Tag name (e.g. v1.0.0)"
         required: false
         type: string
-        default: ''
+        default: ""
       release_title:
-        description: 'Release Title (optional)'
+        description: "Release Title (optional)"
         required: false
         type: string
       # release_body:
@@ -24,12 +24,12 @@ on:
       #   required: false
       #   type: string
       create_release:
-        description: 'Create GitHub Release'
+        description: "Create GitHub Release"
         required: true
         type: boolean
         default: false
       auto_release_note:
-        description: 'Generate release note'
+        description: "Generate release note"
         required: true
         type: boolean
         default: false
@@ -77,6 +77,7 @@ jobs:
             cross: true
             final_name: linux_arm32
           - build: x86_64-macos
+            dep_target: 10.15 # pre-M1 devices
             os: macos-latest
             rust: stable
             target: x86_64-apple-darwin
@@ -89,6 +90,7 @@ jobs:
             cross: false
             final_name: windows_x86_64
           - build: aarch64-macos
+            dep_target: 11 # M1 & post-M1
             os: macos-latest
             rust: stable
             target: aarch64-apple-darwin
@@ -154,6 +156,10 @@ jobs:
       - name: Build binary
         shell: bash
         run: |
+          if [[ "${{ matrix.build }}" =~ "macos" ]]; then
+            export MACOSX_DEPLOYMENT_TARGET=${{ matrix.dep_target }}
+          fi
+
           PROFILE=${{ steps.determine_profile.outputs.profile }}
           if [ "${{ matrix.cross }}" = "true" ]; then
             cross build --profile $PROFILE --target ${{ matrix.target }}


### PR DESCRIPTION
### Background

macOS Big Sur (11) came bundled with the M1 chipset back when it was released, so setting a universal deployment target of 10.15 (refers to macOS Catalina) misses out on some platform-specific updates made to the macOS SDK over time. This PR aims to fix this tiny issue.

### [Workflow Stats](https://github.com/hitblast/quantumlauncher/actions)

<img width="637" height="295" alt="image" src="https://github.com/user-attachments/assets/03e3470c-8ba3-46ca-b35b-462cf97044da" />
