### PR TITLE
fix: navigate back to settings after clearing Java installs

### DIFF
--- a/quantum_launcher/src/message_update/mod.rs
+++ b/quantum_launcher/src/message_update/mod.rs
@@ -551,7 +551,11 @@ impl Launcher {
                 self.confirm_clear_java_installs();
             }
             LauncherSettingsMessage::ClearJavaInstallsConfirm => {
-                return Task::perform(ql_instances::delete_java_installs(), |()| Message::Nothing);
+                return Task::perform(ql_instances::delete_java_installs(), |()| {
+                    Message::LauncherSettings(LauncherSettingsMessage::ChangeTab(
+                        state::LauncherSettingsTab::Internal,
+                    ))
+                });
             }
             LauncherSettingsMessage::ChangeTab(tab) => {
                 self.go_to_launcher_settings();


### PR DESCRIPTION
closes #161 