### PR TITLE
 updated cutoff version from 26.1-snapshot-1 -> 26.1-snap1

### DIFF
--- a/crates/ql_core/src/json/manifest.rs
+++ b/crates/ql_core/src/json/manifest.rs
@@ -51,6 +51,7 @@ impl Manifest {
             "https://raw.githubusercontent.com/theofficialgman/piston-meta-arm32/refs/heads/main/mc/game/version_manifest_v2.json";
 
         const LAST_BETTERJSONS: &str = "26.1-snapshot-1";
+        const LAST_BETTERJSONS_ALT: &str = "26.1-snap1";
 
         // An out-of-date but curated manifest
         const OLDER_VERSIONS_JSON: &str =
@@ -76,12 +77,15 @@ impl Manifest {
 
         // Removes newer versions from out-of-date manifest
         // if it ever gets updated, to not mess up the list.
-        older_manifest.versions =
-            exclude_versions_after(&older_manifest.versions, |n| n.id == LAST_BETTERJSONS);
+        older_manifest.versions = exclude_versions_after(&older_manifest.versions, |n| {
+            n.id == LAST_BETTERJSONS || n.id == LAST_BETTERJSONS_ALT
+        });
         // Add newer versions (that lack fixes/polish) to the manifest
         older_manifest.versions.splice(
             0..0,
-            include_versions_after(&newer_manifest.versions, |n| n.id == LAST_BETTERJSONS),
+            include_versions_after(&newer_manifest.versions, |n| {
+                n.id == LAST_BETTERJSONS || n.id == LAST_BETTERJSONS_ALT
+            }),
         );
 
         Ok(older_manifest)

--- a/crates/ql_instances/src/instance/list_versions.rs
+++ b/crates/ql_instances/src/instance/list_versions.rs
@@ -7,7 +7,11 @@ use ql_core::{json::Manifest, JsonDownloadError, ListEntry, ListEntryKind};
 /// If [`Manifest`] couldn't be downloaded or parsed into JSON
 pub async fn list_versions() -> Result<(Vec<ListEntry>, String), JsonDownloadError> {
     let manifest = Manifest::download().await?;
-    let latest = manifest.get_latest_release().unwrap().id.clone();
+    let latest = manifest
+        .get_latest_release()
+        .or_else(|| manifest.versions.first())
+        .map(|version| version.id.clone())
+        .unwrap_or_default();
 
     Ok((
         manifest


### PR DESCRIPTION
BetterJSON changed snapshot version format from `26.1-snapshot-1`  to `26.1-snap1`, breaking version cutoff detection

Added ALT constant to handle both formats for compatibility

Also replaced unwrap() in list_versions with graceful fallback
to prevent panic(aka dont crash) when no release version is found