### PR TITLE
Workflow: Fix aws-lc-sys build crash on i686-windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
             final_name: windows_aarch64
           - build: i686-windows
             os: windows-latest
-            rust: stable-i686
+            rust: stable
             target: i686-pc-windows-msvc
             cross: false
             final_name: windows_i686


### PR DESCRIPTION
### Problem:
Builds for the `i686-windows` target were failing during the compilation of `aws-lc-sys` with the following error:
`exit code: 0xc0000139, STATUS_ENTRYPOINT_NOT_FOUND`

### Solution:
Changed the host toolchain in the matrix for the `i686-windows` job from `stable-i686` to `stable`.