### PR TITLE
Rich Presence: Fix timestamp bug (backend change)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "filthy-rich"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac7c16eb8bd33384a9f0a282b6ead92ff9af9796a7dcaad62d42ce7d2e1371f"
+checksum = "79da5ad086bcecca84842d37764390dbc62aadb7e5f8e4d70bc5c408015bef23"
 dependencies = [
  "anyhow",
  "serde",

--- a/quantum_launcher/Cargo.toml
+++ b/quantum_launcher/Cargo.toml
@@ -65,7 +65,7 @@ chrono.workspace = true # Logging time/date
 paste = "1" # Icon widget macro
 rfd.workspace = true # File picker
 # For Discord Rich Presence management
-filthy-rich = "0.8.3"
+filthy-rich = "0.8.4"
 # Launcher Update
 thiserror.workspace = true
 zip.workspace = true


### PR DESCRIPTION
This PR updates the `filthy-rich` backend for managing the Rich Presences to fix an important bug related to improper timestamps when Discord is closed and reopened.
