### PR TITLE
Set application id for linux wm integration

### DIFF
--- a/.github/workflows/build-appimage.yml
+++ b/.github/workflows/build-appimage.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           mkdir -p AppDir/usr/bin AppDir/usr/share/applications AppDir/usr/share/icons/hicolor/{256x256,512x512}/apps
           cp target/${{ matrix.target }}/release/${{ env.BIN_NAME }} AppDir/usr/bin/quantum-launcher
-          cp assets/freedesktop/quantum-launcher.desktop AppDir/usr/share/applications/
+          cp assets/freedesktop/quantum-launcher.desktop AppDir/usr/share/applications/io.github.Mrmayman.QuantumLauncher.desktop
           cp assets/icon/256x256/ql_logo.png AppDir/usr/share/icons/hicolor/256x256/apps/io.github.Mrmayman.QuantumLauncher.png
           cp assets/icon/512x512/ql_logo.png AppDir/usr/share/icons/hicolor/512x512/apps/io.github.Mrmayman.QuantumLauncher.png
           linuxdeploy --appdir AppDir

--- a/assets/freedesktop/quantum-launcher.desktop
+++ b/assets/freedesktop/quantum-launcher.desktop
@@ -8,3 +8,4 @@ Categories=Game;
 Icon=io.github.Mrmayman.QuantumLauncher
 Exec=quantum-launcher
 PrefersNonDefaultGPU=true
+StartupWMClass=io.github.Mrmayman.QuantumLauncher

--- a/quantum_launcher.spec
+++ b/quantum_launcher.spec
@@ -26,19 +26,19 @@ cargo build --profile release
 
 %install
 install -Dm755 target/release/quantum_launcher %{buildroot}%{_bindir}/quantum-launcher
-install -Dm644 assets/freedesktop/quantum-launcher.desktop %{buildroot}%{_datadir}/applications/quantum-launcher.desktop
+install -Dm644 assets/freedesktop/quantum-launcher.desktop %{buildroot}%{_datadir}/applications/io.github.Mrmayman.QuantumLauncher.desktop
 install -Dm644 assets/icon/256x256/ql_logo.png %{buildroot}%{_datadir}/pixmaps/io.github.Mrmayman.QuantumLauncher.png
 install -Dm644 assets/icon/256x256/ql_logo.png %{buildroot}%{_datadir}/icons/hicolor/256x256/apps/io.github.Mrmayman.QuantumLauncher.png
-install -Dm644 assets/freedesktop/quantum-launcher.metainfo.xml %{buildroot}%{_datadir}/metainfo/quantum-launcher.metainfo.xml
+install -Dm644 assets/freedesktop/quantum-launcher.metainfo.xml %{buildroot}%{_datadir}/metainfo/io.github.Mrmayman.QuantumLauncher.metainfo.xml
 
 %files
 %license LICENSE
 %doc README.md
 %{_bindir}/quantum-launcher
-%{_datadir}/applications/quantum-launcher.desktop
+%{_datadir}/applications/io.github.Mrmayman.QuantumLauncher.desktop
 %{_datadir}/pixmaps/io.github.Mrmayman.QuantumLauncher.png
 %{_datadir}/icons/hicolor/256x256/apps/io.github.Mrmayman.QuantumLauncher.png
-%{_datadir}/metainfo/quantum-launcher.metainfo.xml
+%{_datadir}/metainfo/io.github.Mrmayman.QuantumLauncher.metainfo.xml
 
 %changelog
 %autochangelog

--- a/quantum_launcher/src/main.rs
+++ b/quantum_launcher/src/main.rs
@@ -229,6 +229,7 @@ fn main() {
             decorations,
             transparent: true,
             platform_specific: iced::window::settings::PlatformSpecific {
+                #[cfg(any(target_os = "linux", target_os = "freebsd"))]
                 application_id: "io.github.Mrmayman.QuantumLauncher".to_owned(),
                 ..Default::default()
             },

--- a/quantum_launcher/src/main.rs
+++ b/quantum_launcher/src/main.rs
@@ -208,6 +208,7 @@ fn main() {
         .scale_factor(Launcher::scale_factor)
         .theme(Launcher::theme)
         .settings(Settings {
+            id: Some("io.github.Mrmayman.QuantumLauncher".to_owned()),
             fonts: load_fonts(),
             default_font: FONT_DEFAULT,
             antialiasing: config
@@ -227,6 +228,10 @@ fn main() {
             }),
             decorations,
             transparent: true,
+            platform_specific: iced::window::settings::PlatformSpecific {
+                application_id: "io.github.Mrmayman.QuantumLauncher".to_owned(),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .run_with(move || Launcher::new(is_new_user, config))


### PR DESCRIPTION
### Changes:
* Updates the application initialization to set a unique application identifier `io.github.Mrmayman.QuantumLauncher` in both the general Iced settings and the platform-specific window settings.
* Updates quantum_launcher.spec and desktop file to match the identifier.

Screenshot of gnome lg:
<img width="415" height="101" alt="screenshot" src="https://github.com/user-attachments/assets/cffb61a4-98b5-4560-855a-234de9bd4627" />
