### PR TITLE
chore: update RPC backend `filthy-rich` to v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,12 +1435,14 @@ dependencies = [
 
 [[package]]
 name = "filthy-rich"
-version = "0.13.2"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566bf8a107125e82d5bd4728ee67283c836807b102cca76a90dacf317ea5ae27"
+checksum = "25dc6a00a631ae713340eb9bf9a897661defbe55d59057e89e8a44e05a07b3ca"
 dependencies = [
+ "bytes",
  "serde",
  "serde_json",
+ "serde_repr",
  "thiserror 2.0.18",
  "tokio",
  "uuid",

--- a/quantum_launcher/Cargo.toml
+++ b/quantum_launcher/Cargo.toml
@@ -66,7 +66,7 @@ constcat = "0.6"
 rand = "0.10" # Instance folder unique id
 
 # For Discord Rich Presence management
-filthy-rich = "0.13.2"
+filthy-rich = "1.0.2"
 # Launcher Update
 thiserror.workspace = true
 zip.workspace = true

--- a/quantum_launcher/src/message_update/discord_rpc.rs
+++ b/quantum_launcher/src/message_update/discord_rpc.rs
@@ -1,6 +1,7 @@
 use filthy_rich::{
     PresenceRunner,
-    types::{Activity, ActivityType},
+    errors::ActivitySpecBuildError,
+    types::{Activity, ActivitySpec, ActivityType},
 };
 use iced::{Task, futures::executor::block_on};
 
@@ -25,7 +26,7 @@ impl Launcher {
                 pt!(
                     no_log,
                     "Connected to user: {}; ready for presence",
-                    f.user.username
+                    f.user.username()
                 );
                 *p = PresenceConnectionState::Connected;
             })
@@ -34,7 +35,8 @@ impl Launcher {
                 pt!(
                     no_log,
                     "Presence activity received for app: {}",
-                    f.application_id
+                    f.application_id()
+                        .unwrap_or("(no application ID found in response)")
                 );
                 *p = PresenceConnectionState::Active;
             })
@@ -148,17 +150,15 @@ impl Launcher {
 
         Task::perform(
             async move {
-                _ = c
-                    .set_activity(bake_activity(
-                        name,
-                        sdt,
-                        competing,
-                        details,
-                        details_url,
-                        state,
-                        state_url,
-                    ))
-                    .await;
+                let activity =
+                    bake_activity(name, sdt, competing, details, details_url, state, state_url);
+
+                match activity {
+                    Ok(a) => {
+                        _ = c.set_activity(a).await;
+                    }
+                    Err(e) => err!(no_log, "Failed to bake custom RPC activity: {e}"),
+                }
             },
             |_| Message::Nothing,
         )
@@ -201,17 +201,20 @@ impl Launcher {
                         let instance = selected_instance.get_name();
                         let minecraft_vers = version_details.get_id();
 
-                        _ = c
-                            .set_activity(bake_activity(
-                                name,
-                                sdt,
-                                competing,
-                                details.map(|f| f.substitute(instance, minecraft_vers)),
-                                details_url,
-                                state.map(|f| f.substitute(instance, minecraft_vers)),
-                                state_url,
-                            ))
-                            .await;
+                        let activity = bake_activity(
+                            name,
+                            sdt,
+                            competing,
+                            details.map(|f| f.substitute(instance, minecraft_vers)),
+                            details_url,
+                            state.map(|f| f.substitute(instance, minecraft_vers)),
+                            state_url,
+                        );
+
+                        match activity {
+                            Ok(a) => _ = c.set_activity(a).await,
+                            Err(e) => err!(no_log, "Failed to bake RPC game update activity: {e}"),
+                        }
                     }
                 }
             },
@@ -249,7 +252,7 @@ pub fn bake_activity(
     details_url: Option<String>,
     state: Option<String>,
     state_url: Option<String>,
-) -> Activity {
+) -> Result<ActivitySpec, ActivitySpecBuildError> {
     let mut activity = Activity::new()
         .activity_type(if competing {
             ActivityType::Competing

--- a/tests/src/main.rs
+++ b/tests/src/main.rs
@@ -34,7 +34,6 @@ struct Cli {
     #[arg(help = "See all the logs to diagnose issues")]
     verbose: bool,
 }
-
 impl Cli {
     fn get_versions(&self) -> impl Iterator<Item = &Version> {
         VERSIONS_LWJGL2.iter().chain(


### PR DESCRIPTION
## tl;dr

Early on, QuantumLauncher was using the pre-v1 versions of the `filthy-rich` backend for its Rich Presence functionality. However, recently, v1 has finally been released and comes with a few feature upgrades.

This PR adds that version to QL.
