### PR TITLE
fix: #179; add dynamic memory limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1435,9 +1435,9 @@ dependencies = [
 
 [[package]]
 name = "filthy-rich"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dc6a00a631ae713340eb9bf9a897661defbe55d59057e89e8a44e05a07b3ca"
+checksum = "a6a018b0fc04824b50ab96cf584a86b45f4e266f9365111aefa54f77e6fb7535"
 dependencies = [
  "bytes",
  "serde",
@@ -4080,6 +4080,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sysinfo",
  "terminal_size",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1"
 semver = "1"
 dirs = "6"
 
+sysinfo = "0.36.*"
 reqwest = { version = "0.13.*", features = ["json", "stream", "query", "form"] }
 
 tokio = { version = "1", features = ["fs", "macros", "process", "rt", "rt-multi-thread"] }

--- a/quantum_launcher/Cargo.toml
+++ b/quantum_launcher/Cargo.toml
@@ -64,9 +64,10 @@ paste = "1" # Icon widget macro
 rfd.workspace = true # File picker
 constcat = "0.6"
 rand = "0.10" # Instance folder unique id
+sysinfo.workspace = true # Dynamic min/max RAM allocation
 
 # For Discord Rich Presence management
-filthy-rich = "1.0.2"
+filthy-rich = "1.0.5"
 # Launcher Update
 thiserror.workspace = true
 zip.workspace = true

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -72,7 +72,7 @@ impl MenuEditInstance {
                     .font(FONT_MONO)
             ]
             .push_maybe(
-                (!self.is_editing_name).then_some(
+                (!self.state_rename.is_editing).then_some(
                     widget::button(
                         icons::edit_s(12).style(|t: &LauncherTheme| t.style_text(Color::Mid))
                     )
@@ -96,10 +96,10 @@ impl MenuEditInstance {
         .width(Length::Fill)
         .spacing(5)
         .push_maybe(
-            self.is_editing_name.then_some(
+            self.state_rename.is_editing.then_some(
                 column![
                     widget::Space::with_height(1),
-                    widget::text_input("Rename Instance", &self.instance_name)
+                    widget::text_input("Rename Instance", &self.state_rename.name)
                         .on_input(|n| EditInstanceMessage::RenameEdit(n).into()),
                     row![
                         widget::button(widget::text("Rename").size(12))
@@ -203,10 +203,9 @@ impl MenuEditInstance {
 
     fn item_mem_alloc(&self) -> Column<'_> {
         // total RAM of system
-        let system = sysinfo::System::new_all();
-        let total_mem = system.total_memory() as f32 / 1024_f32.powf(2.0);
+        let total_mem = self.state_ram.system.total_memory() as f32 / 1024_f32.powf(2.0);
         let mem_256_mb_in_twos_exponent: f32 = 256_f32.ln() / 2_f32.ln();
-        let mem_max_in_twos_exponent: f32 = (total_mem as f32).ln() / 2_f32.ln();
+        let mem_max_in_twos_exponent: f32 = total_mem.ln() / 2_f32.ln();
         let mem_warning_threshold = ((total_mem) * 0.7) as usize; // 70%
 
         column![
@@ -220,10 +219,10 @@ Heavy modpacks / High settings: 4-8 GB+"
             .style(tsubtitle),
             widget::Space::with_height(5),
             row![
-                widget::text(&self.slider_text),
+                widget::text(&self.state_ram.slider_text),
                 widget::slider(
                     mem_256_mb_in_twos_exponent..=mem_max_in_twos_exponent,
-                    self.slider_value,
+                    self.state_ram.slider_value,
                     |n| EditInstanceMessage::MemoryChanged(n).into()
                 )
                 .step(0.1),
@@ -232,7 +231,7 @@ Heavy modpacks / High settings: 4-8 GB+"
             .spacing(10),
             row![
                 widget::text("Or enter directly:").size(12).style(tsubtitle),
-                widget::text_input("2048", &self.memory_input)
+                widget::text_input("2048", &self.state_ram.memory_input)
                     .on_input(|n| EditInstanceMessage::MemoryInputChanged(n).into())
                     .width(64)
                     .size(12),
@@ -244,7 +243,7 @@ Heavy modpacks / High settings: 4-8 GB+"
         .push_maybe(
             (self.config.ram_in_mb > mem_warning_threshold).then_some(
                 widget::text(
-                    "Warning: Very high RAM allocated! (70% of total)\nYour system may struggle",
+                    "Warning: Very high RAM allocated! (More than 70% of total)\nYour system may struggle",
                 )
                 .size(14),
             ),

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -205,7 +205,7 @@ impl MenuEditInstance {
         // total RAM of system
         let total_mem = self.state_ram.system.total_memory() as f32 / 1024_f32.powf(2.0);
         let mem_256_mb_in_twos_exponent: f32 = 256_f32.ln() / 2_f32.ln();
-        let mem_max_in_twos_exponent: f32 = total_mem.ln() / 2_f32.ln();
+        let mem_max_in_twos_exponent: f32 = total_mem.ln().max(256_f32.ln()) / 2_f32.ln();
         let mem_warning_threshold = ((total_mem) * 0.7) as usize; // 70%
 
         column![

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -202,10 +202,11 @@ impl MenuEditInstance {
     }
 
     fn item_mem_alloc(&self) -> Column<'_> {
-        // 2 ^ 8 = 256 MB
-        const MEM_256_MB_IN_TWOS_EXPONENT: f32 = 8.0;
-        // 2 ^ 15 = 32768 MB (32 GB)
-        const MEM_32768_MB_IN_TWOS_EXPONENT: f32 = 15.0;
+        // total RAM of system
+        let system = sysinfo::System::new_all();
+        let total_mem = system.total_memory() as f32 / 1024_f32.powf(2.0);
+        let mem_256_mb_in_twos_exponent: f32 = 256_f32.ln() / 2_f32.ln();
+        let mem_max_in_twos_exponent: f32 = (total_mem as f32).ln() / 2_f32.ln();
 
         const RAM_16_GB_TO_MB: usize = 16384;
 
@@ -222,7 +223,7 @@ Heavy modpacks / High settings: 4-8 GB+"
             row![
                 widget::text(&self.slider_text),
                 widget::slider(
-                    MEM_256_MB_IN_TWOS_EXPONENT..=MEM_32768_MB_IN_TWOS_EXPONENT,
+                    mem_256_mb_in_twos_exponent..=mem_max_in_twos_exponent,
                     self.slider_value,
                     |n| EditInstanceMessage::MemoryChanged(n).into()
                 )

--- a/quantum_launcher/src/menu_renderer/edit_instance.rs
+++ b/quantum_launcher/src/menu_renderer/edit_instance.rs
@@ -207,8 +207,7 @@ impl MenuEditInstance {
         let total_mem = system.total_memory() as f32 / 1024_f32.powf(2.0);
         let mem_256_mb_in_twos_exponent: f32 = 256_f32.ln() / 2_f32.ln();
         let mem_max_in_twos_exponent: f32 = (total_mem as f32).ln() / 2_f32.ln();
-
-        const RAM_16_GB_TO_MB: usize = 16384;
+        let mem_warning_threshold = ((total_mem) * 0.7) as usize; // 70%
 
         column![
             "Allocated memory",
@@ -243,9 +242,9 @@ Heavy modpacks / High settings: 4-8 GB+"
             .spacing(5)
         ]
         .push_maybe(
-            (self.config.ram_in_mb > RAM_16_GB_TO_MB).then_some(
+            (self.config.ram_in_mb > mem_warning_threshold).then_some(
                 widget::text(
-                    "Warning: Very high RAM allocated! (16+ GB)\nYour system may struggle",
+                    "Warning: Very high RAM allocated! (70% of total)\nYour system may struggle",
                 )
                 .size(14),
             ),

--- a/quantum_launcher/src/message_update/edit_instance.rs
+++ b/quantum_launcher/src/message_update/edit_instance.rs
@@ -13,9 +13,10 @@ use ql_core::{
 use crate::{
     config::sidebar::SidebarSelection,
     state::{
-        ADD_JAR_NAME, AutoSaveKind, CustomJarState, EditInstanceMessage, LaunchTab, Launcher,
-        MainMenuMessage, MenuCreateInstance, MenuEditInstance, MenuLaunch, Message, NONE_JAR_NAME,
-        OPEN_FOLDER_JAR_NAME, ProgressBar, REMOVE_JAR_NAME, State, dir_watch, get_entries,
+        ADD_JAR_NAME, AutoSaveKind, CustomJarState, EditInstanceMessage, EditInstanceRam,
+        EditInstanceRename, LaunchTab, Launcher, MainMenuMessage, MenuCreateInstance,
+        MenuEditInstance, MenuLaunch, Message, NONE_JAR_NAME, OPEN_FOLDER_JAR_NAME, ProgressBar,
+        REMOVE_JAR_NAME, State, dir_watch, get_entries,
     },
 };
 
@@ -103,10 +104,10 @@ impl Launcher {
                     ..
                 }) = &mut self.state
                 {
-                    menu.slider_value = new_slider_value;
                     menu.config.ram_in_mb = 2f32.powf(new_slider_value) as usize;
-                    menu.slider_text = format_memory(menu.config.ram_in_mb);
-                    menu.memory_input = menu.config.ram_in_mb.to_string();
+                    menu.state_ram.slider_value = new_slider_value;
+                    menu.state_ram.slider_text = format_memory(menu.config.ram_in_mb);
+                    menu.state_ram.memory_input = menu.config.ram_in_mb.to_string();
                 }
             }
             EditInstanceMessage::MemoryInputChanged(input) => {
@@ -118,11 +119,11 @@ impl Launcher {
                     if let Ok(mb) = input.parse::<usize>() {
                         if mb > 0 {
                             menu.config.ram_in_mb = mb;
-                            menu.slider_value = f32::log2(mb as f32);
-                            menu.slider_text = format_memory(mb);
+                            menu.state_ram.slider_value = f32::log2(mb as f32);
+                            menu.state_ram.slider_text = format_memory(mb);
                         }
                     }
-                    menu.memory_input = input;
+                    menu.state_ram.memory_input = input;
                 }
             }
             EditInstanceMessage::LoggingToggle(t) => iflet_config!(&mut self.state, config <- {
@@ -166,8 +167,8 @@ impl Launcher {
                         .as_ref()
                         .unwrap()
                         .get_name()
-                        .clone_into(&mut menu.instance_name);
-                    menu.is_editing_name = !menu.is_editing_name;
+                        .clone_into(&mut menu.state_rename.name);
+                    menu.state_rename.is_editing = !menu.state_rename.is_editing;
                 }
             }
             EditInstanceMessage::RenameEdit(n) => {
@@ -176,7 +177,7 @@ impl Launcher {
                     ..
                 }) = &mut self.state
                 {
-                    menu.instance_name = n;
+                    menu.state_rename.name = n;
                 }
             }
             EditInstanceMessage::RenameApply => return self.rename_instance(),
@@ -278,25 +279,32 @@ impl Launcher {
         ) -> Result<(), JsonFileError> {
             let config_path = selected_instance.get_instance_path().join("config.json");
 
-            let config_json = std::fs::read_to_string(&config_path).path(config_path)?;
-            let config_json: InstanceConfigJson =
-                serde_json::from_str(&config_json).json(config_json)?;
+            let config = std::fs::read_to_string(&config_path).path(config_path)?;
+            let config: InstanceConfigJson = serde_json::from_str(&config).json(config)?;
 
-            let slider_value = f32::log2(config_json.ram_in_mb as f32);
-            let memory_mb = config_json.ram_in_mb;
+            let slider_value = f32::log2(config.ram_in_mb as f32);
+            let memory_mb = config.ram_in_mb;
 
             // Use this to check for performance impact
             // std::thread::sleep(std::time::Duration::from_millis(500));
 
             *edit_instance = Some(MenuEditInstance {
-                main_class_mode: config_json.get_main_class_mode(),
-                config: config_json,
-                slider_value,
-                instance_name: selected_instance.name.to_string(),
-                old_instance_name: selected_instance.name.clone(),
-                slider_text: format_memory(memory_mb),
-                memory_input: memory_mb.to_string(),
-                is_editing_name: false,
+                main_class_mode: config.get_main_class_mode(),
+                config,
+                state_ram: EditInstanceRam {
+                    slider_value,
+                    slider_text: format_memory(memory_mb),
+                    memory_input: memory_mb.to_string(),
+                    system: sysinfo::System::new_with_specifics(
+                        sysinfo::RefreshKind::nothing()
+                            .with_memory(sysinfo::MemoryRefreshKind::everything()),
+                    ),
+                },
+                state_rename: EditInstanceRename {
+                    name: selected_instance.name.to_string(),
+                    old_name: selected_instance.name.clone(),
+                    is_editing: false,
+                },
                 arg_split_by_space: true,
             });
             Ok(())
@@ -420,14 +428,14 @@ impl Launcher {
             return Ok(Task::none());
         };
 
-        let sanitized_name = sanitize_instance_name(menu.instance_name.clone());
+        let sanitized_name = sanitize_instance_name(menu.state_rename.name.clone());
         if sanitized_name.is_empty() {
             err!("New name is empty or invalid");
             return Ok(Task::none());
         }
 
-        if *menu.old_instance_name == sanitized_name
-            || *menu.old_instance_name == menu.instance_name
+        if *menu.state_rename.old_name == sanitized_name
+            || *menu.state_rename.old_name == menu.state_rename.name
         {
             // Don't waste time talking to OS
             // and "renaming" instance if nothing has changed.
@@ -441,7 +449,7 @@ impl Launcher {
                 "instances"
             });
 
-        let old_path = instances_dir.join(&*menu.old_instance_name);
+        let old_path = instances_dir.join(&*menu.state_rename.old_name);
         let new_path = instances_dir.join(&sanitized_name);
 
         if new_path.parent().is_none_or(|n| n != instances_dir) {
@@ -449,8 +457,8 @@ impl Launcher {
             return Ok(Task::none());
         }
 
-        let old_name = menu.old_instance_name.clone();
-        menu.old_instance_name = Arc::from(sanitized_name.as_str());
+        let old_name = menu.state_rename.old_name.clone();
+        menu.state_rename.old_name = Arc::from(sanitized_name.as_str());
         std::fs::rename(&old_path, &new_path)
             .path(&old_path)
             .strerr()?;

--- a/quantum_launcher/src/state/menu.rs
+++ b/quantum_launcher/src/state/menu.rs
@@ -192,17 +192,24 @@ impl MenuLaunch {
 pub struct MenuEditInstance {
     pub config: InstanceConfigJson,
 
-    // Renaming Instance:
-    pub is_editing_name: bool,
-    pub instance_name: String,
-    pub old_instance_name: Arc<str>,
-    // Changing RAM:
-    pub slider_value: f32,
-    pub slider_text: String,
-    pub memory_input: String,
+    pub state_rename: EditInstanceRename,
+    pub state_ram: EditInstanceRam,
 
     pub main_class_mode: Option<MainClassMode>,
     pub arg_split_by_space: bool,
+}
+
+pub struct EditInstanceRename {
+    pub is_editing: bool,
+    pub name: String,
+    pub old_name: Arc<str>,
+}
+
+pub struct EditInstanceRam {
+    pub slider_value: f32,
+    pub slider_text: String,
+    pub memory_input: String,
+    pub system: sysinfo::System,
 }
 
 pub enum SelectedState {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,9 +13,9 @@ ql_core.path = "../crates/ql_core"
 tokio.workspace = true
 clap.workspace = true
 owo-colors.workspace = true
+sysinfo.workspace = true
 
 duct = "1"
-sysinfo = "0.36.*"
 which = "8.0.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Fixes: #179 
- [x] The maximum slider limit for RAM is now fetched dynamically (used the `sysinfo` crate as proposed in #179).
- [x] The warning threshold for "very high allocation" is now at 70% of the total RAM instead of a hardcoded value of 16 gigabytes.

This PR also updates the `filthy-rich` backend to v1.0.5 as part of maintenance.