### PR TITLE
RFC: Update rust-toolchain.toml to pin compiler to v1.88.0

### DIFF
--- a/crates/ezshortcut/Cargo.toml
+++ b/crates/ezshortcut/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ezshortcut"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 cfg-if.workspace = true

--- a/crates/ql_core/Cargo.toml
+++ b/crates/ql_core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_core"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [features]
 default = []

--- a/crates/ql_instances/Cargo.toml
+++ b/crates/ql_instances/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_instances"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 
 [features]

--- a/crates/ql_java_handler/Cargo.toml
+++ b/crates/ql_java_handler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_java_handler"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [features]
 default = []

--- a/crates/ql_mod_manager/Cargo.toml
+++ b/crates/ql_mod_manager/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_mod_manager"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/crates/ql_packager/Cargo.toml
+++ b/crates/ql_packager/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_packager"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/crates/ql_servers/Cargo.toml
+++ b/crates/ql_servers/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ql_servers"
 version = "0.0.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 
 [dependencies]

--- a/quantum_launcher/Cargo.toml
+++ b/quantum_launcher/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quantum_launcher"
 version = "0.5.1"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 
 authors = ["Mrmayman <navneetkrishna22@gmail.com>"]
 description = "A simple, powerful Minecraft Launcher"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "GPL-3.0-only"
 
 [dependencies]


### PR DESCRIPTION
# tl;dr

This update is required to support newer crate versions and APIs used by the project, specifically:

- `http-crate-reqwest`
- `rpassword`

Updating the pinned Rust toolchain to `1.88.0` allows us to use these crates without relying on outdated versions or compatibility workarounds.

This RFC is open to discussion regarding:
- MSRV policy
- Alternative crate versions
- CI/toolchain impact
- Whether `1.88.0` should become the new minimum supported Rust version